### PR TITLE
fix(Web): Added viewport meta tag

### DIFF
--- a/packages/web/src/webpack/middlewares/ClientHTML/index.ts
+++ b/packages/web/src/webpack/middlewares/ClientHTML/index.ts
@@ -38,6 +38,8 @@ const ClientHTML: WebpackBuilderMiddleware = () => (config: WebpackConfig, build
 						// removeNilAttributes: true,
 						useShortDoctype: true,
 					},
+
+					meta: { viewport: 'width=device-width, initial-scale=1, shrink-to-fit=no' },
 					production: true,
 					template: `${path.resolve(__dirname, './template.js')}`,
 					// We pass our config and client config script compoent as it will


### PR DESCRIPTION
## What I did
@artalat 
Added the Meta tag for View port via HtmlWebpackPlugin
I have replaced the lib and tested on both Android and ios and it is working fine.

Closes: #65