### PR TITLE
expo:build command

### DIFF
--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -19,7 +19,7 @@ $ npm install -g @bluebase/cli-expo
 $ bluebase COMMAND
 running command...
 $ bluebase (-v|--version|version)
-@bluebase/cli-expo/0.0.24 darwin-x64 node-v12.4.0
+@bluebase/cli-expo/0.0.25 darwin-x64 node-v12.4.0
 $ bluebase --help [COMMAND]
 USAGE
   $ bluebase COMMAND
@@ -28,10 +28,31 @@ USAGE
 <!-- usagestop -->
 # Commands
 <!-- commands -->
+* [`bluebase expo:build`](#bluebase-expobuild)
 * [`bluebase expo:build:android`](#bluebase-expobuildandroid)
 * [`bluebase expo:build:ios`](#bluebase-expobuildios)
 * [`bluebase expo:init`](#bluebase-expoinit)
 * [`bluebase expo:start`](#bluebase-expostart)
+
+## `bluebase expo:build`
+
+creates a expo build directory with app.json file
+
+```
+USAGE
+  $ bluebase expo:build
+
+OPTIONS
+  --appJsPath=appJsPath  [default: ./bluebase/expo/App] Path to App.js file relative to the root directory
+  --assetsDir=assetsDir  [default: ./assets/expo] Path to assets directory relative to the root directory
+  --buildDir=buildDir    [default: ./build/expo] Path to build directory relative to the root directory
+  --configDir=configDir  [default: ./bluebase/expo] Path to config directory relative to the root directory
+
+EXAMPLE
+  $ bluebase expo:build
+```
+
+_See code: [src/commands/expo/build.ts](https://github.com/BlueBaseJS/cli/blob/v0.0.25/src/commands/expo/build.ts)_
 
 ## `bluebase expo:build:android`
 
@@ -51,7 +72,7 @@ EXAMPLE
   $ bluebase expo:build:android
 ```
 
-_See code: [src/commands/expo/build/android.ts](https://github.com/BlueBaseJS/cli/blob/v0.0.24/src/commands/expo/build/android.ts)_
+_See code: [src/commands/expo/build/android.ts](https://github.com/BlueBaseJS/cli/blob/v0.0.25/src/commands/expo/build/android.ts)_
 
 ## `bluebase expo:build:ios`
 
@@ -71,7 +92,7 @@ EXAMPLE
   $ bluebase expo:build:ios
 ```
 
-_See code: [src/commands/expo/build/ios.ts](https://github.com/BlueBaseJS/cli/blob/v0.0.24/src/commands/expo/build/ios.ts)_
+_See code: [src/commands/expo/build/ios.ts](https://github.com/BlueBaseJS/cli/blob/v0.0.25/src/commands/expo/build/ios.ts)_
 
 ## `bluebase expo:init`
 
@@ -91,7 +112,7 @@ EXAMPLE
   $ bluebase expo:init
 ```
 
-_See code: [src/commands/expo/init.ts](https://github.com/BlueBaseJS/cli/blob/v0.0.24/src/commands/expo/init.ts)_
+_See code: [src/commands/expo/init.ts](https://github.com/BlueBaseJS/cli/blob/v0.0.25/src/commands/expo/init.ts)_
 
 ## `bluebase expo:start`
 
@@ -111,5 +132,5 @@ EXAMPLE
   $ bluebase expo:start
 ```
 
-_See code: [src/commands/expo/start.ts](https://github.com/BlueBaseJS/cli/blob/v0.0.24/src/commands/expo/start.ts)_
+_See code: [src/commands/expo/start.ts](https://github.com/BlueBaseJS/cli/blob/v0.0.25/src/commands/expo/start.ts)_
 <!-- commandsstop -->

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@bluebase/cli-expo",
 	"description": "An Expo plugin for BlueBaseJS CLI",
-	"version": "0.0.24",
+	"version": "0.0.25",
 	"author": "BlueEast Team <code@blueeast.com>",
 	"bugs": "https://github.com/BlueBaseJS/cli/issues",
 	"main": "./lib",
@@ -61,11 +61,10 @@
 			"@oclif/plugin-help"
 		]
 	},
-
 	"repository": "BlueBaseJS/cli",
 	"scripts": {
 		"fix": "run-s fix:*",
-    "fix:tslint": "tslint --fix --project .",
+		"fix:tslint": "tslint --fix --project .",
 		"build": "run-s clean && run-p build:*",
 		"build:main": "tsc -p tsconfig.json && babel ./src --out-dir lib --extensions \".ts,.tsx\"",
 		"lint": "tslint -t stylish --project \"tsconfig.json\"",

--- a/packages/expo/src/commands/expo/build.ts
+++ b/packages/expo/src/commands/expo/build.ts
@@ -1,0 +1,46 @@
+import { ExpoFlagDefs, ExpoFlags } from '../../flags';
+
+import { Command } from '@oclif/command';
+import { Utils } from '@bluebase/cli-core';
+import { createBundle } from '../../scripts';
+
+export default class ExpoBuild extends Command {
+	static description = 'creates a expo build directory with app.json file';
+
+	static examples = [`$ bluebase expo:build`];
+
+	static flags = ExpoFlagDefs;
+	// static flags = ExpoFlagDefs;
+
+	async run() {
+		const parsed = this.parse(ExpoBuild);
+		const flags = parsed.flags as ExpoFlags;
+
+		Utils.logger.log({
+			label: '@bluebase/cli/expo',
+			level: 'info',
+			message: '🏗 Building android project...'
+		});
+
+		// run expo:ios build script
+		const buildDir = Utils.fromProjectRoot(flags.buildDir);
+		const configDir = Utils.fromProjectRoot(flags.configDir);
+		const assetsDir = Utils.fromProjectRoot(flags.assetsDir);
+		const appJsPath = Utils.fromProjectRoot(flags.appJsPath);
+
+		/////////////////////////////
+		///// Transpile & Build /////
+		/////////////////////////////
+
+		// const transiplePath = path.join(buildDir, 'dist');
+		await createBundle({
+			appJsPath,
+			assetsDir,
+			buildDir,
+			configDir,
+			name: 'expo'
+		});
+
+		return;
+	}
+}


### PR DESCRIPTION
Adds `expo:build` command.

## Motivation and Context
In BlueBase we use a custom folder strucutre  to manage different platforms. This is different from what Expo Cli expects. The command is used to generate `app.json` and related files, that can be used to Expo Cli to build and run projects.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.