### PR TITLE
fix(expo-cli version): expo cli version upgrade from 2.6 to 3.0.10

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -17,7 +17,7 @@
 		"@bluebase/code-standards": "^1.0.3",
 		"@oclif/command": "^1",
 		"@oclif/config": "^1",
-		"expo-cli": "^2.19.4",
+		"expo-cli": "^3.0.10",
 		"metro-react-native-babel-preset": "^0.53.1",
 		"rimraf": "^2.6.3",
 		"semver": "^6.0.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I just updated the version of expo-cli from 2.6 to 3.0.10 because the previous version was unable to open expo dashboard on browser showing only a black screen. A bit of googling and forums led me to this solution.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Upgrading from expo-cli version 2.6 to 3.0.10 resolves the issue of black screen when expo dashboard was opened in browser. It also fixes tunnel related issues when connecting and scanning through expo app.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.