### PR TITLE
fix(Expo): changes in config are being transfered to app json

### DIFF
--- a/packages/expo/src/scripts/bundle/getAppJson.ts
+++ b/packages/expo/src/scripts/bundle/getAppJson.ts
@@ -6,9 +6,8 @@ import path from 'path';
 // tslint:disable-next-line:no-var-requires
 require('@babel/register')({
 	extensions: ['.js', '.jsx', '.ts', '.tsx'],
-	presets: ['@bluebase/babel-preset-bluebase'],
+	presets: ['@bluebase/code-standards/babel.config.js'],
 });
-
 
 export interface CreateBundleInterface {
 	assetsDir: string,

--- a/packages/expo/src/scripts/bundle/getAppJson.ts
+++ b/packages/expo/src/scripts/bundle/getAppJson.ts
@@ -2,6 +2,14 @@ import defaultConfigs from '../../configs';
 import { findFile } from './findFile';
 import path from 'path';
 
+// Transpile files on the fly
+// tslint:disable-next-line:no-var-requires
+require('@babel/register')({
+	extensions: ['.js', '.jsx', '.ts', '.tsx'],
+	presets: ['@bluebase/babel-preset-bluebase'],
+});
+
+
 export interface CreateBundleInterface {
 	assetsDir: string,
 	buildDir: string,
@@ -22,7 +30,7 @@ export const getAppJson = async ({ assetsDir, buildDir, configDir }: CreateBundl
 
 	// See if there is a custom config file in the project
 	const configPath = findFile(
-    path.resolve(configDir, 'config.client'),
+    path.resolve(configDir, 'configs'),
     path.resolve(__dirname, './emptyFn.js')
 	);
 

--- a/packages/expo/src/scripts/dependencies.ts
+++ b/packages/expo/src/scripts/dependencies.ts
@@ -8,7 +8,7 @@ import { getLatestExpoVersion } from './expo/getLatestExpoVersion';
 /**
  * List of dependencies required by this plugin
  */
-export const requiredDependencies = [...coreDeps, 'deepmerge'];
+export const requiredDependencies = [...coreDeps, 'deepmerge', '@bluebase/code-standards'];
 
 /**
  * List of dev dependencies required by this plugin


### PR DESCRIPTION
## What I did
The config file name was wrong to generate app.json while making build for expo. It was config.client rather the actual name was configs
Changed that.

Added an on the fly transpiler just like we are using one to override webpack configurations in cli-web.

@artalat Please review and merge it. I have tested app.json, the expo object is now changeable.